### PR TITLE
Ensure the latest connectionsDoc from the docSet is used

### DIFF
--- a/server/genesis.js
+++ b/server/genesis.js
@@ -8,7 +8,7 @@ const makeGenesisDoc = (genesisFile) => {
 }
 
 const loadGenesisDoc = (genesisFile) => {
-  return Automerge.load(fs.readFileSync(genesisFile), 'a32dccb3-6113-499e-a25b-2433bc838ff5')
+  return Automerge.load(fs.readFileSync(genesisFile))
 }
 
 const startFromGenesisDoc = (genesisFile) => {


### PR DESCRIPTION
The error "Cannot pass an old state object to a connection" was due to the fact that the Server object was maintaining its own copy of the connections document in the member variable `this.connectionsDoc`. When a client sent its copy of the connectionsDoc to the server, this would update the `'connections'` entry in the docSet, but not `this.connectionsDoc`. Thus, when subsequently performing `Automerge.change(this.connectionsDoc, ...)`, the document being changed was not the latest document in the docSet.

Updated the code to always get the latest document state from the docSet rather than maintaining a separate member variable.